### PR TITLE
Port code to use generic NatX type instead of custom variants

### DIFF
--- a/src/NatLib.mo
+++ b/src/NatLib.mo
@@ -1,3 +1,5 @@
+import Debug "mo:base/Debug";
+
 module {
     public type NatLib<NatX> = module {
         add : (NatX, NatX) -> NatX;
@@ -17,36 +19,52 @@ module {
         toText : NatX -> Text;
     };
 
-    public type NatLibRec<NatX> =  {
-        add : (NatX, NatX) -> NatX;
-        bitand : (NatX, NatX) -> NatX;
-        bitclear : (NatX, Nat) -> NatX;
-        bitcountNonZero : NatX -> NatX;
-        bitshiftLeft : (NatX, NatX) -> NatX;
-        bitshiftRight : (NatX, NatX) -> NatX;
-        bitnot : NatX -> NatX;
-        bitor : (NatX, NatX) -> NatX;
-        bitset : (NatX, Nat) -> NatX;
-        bittest : (NatX, Nat) -> Bool;
-        div : (NatX, NatX) -> NatX;
-        fromNat : Nat -> NatX;
-        subWrap : (NatX, NatX) -> NatX;
-        toNat : NatX -> Nat;
-    };
-
-    type NatLibX<NatX> = NatLib<NatX> and module {
-        sub: (NatX, NatX) -> NatX
-    };
-
-    public func getMax<NatX>(NatLib: NatLib<NatX>) : NatX {
+    public func getMax<NatX>(NatLib : NatLib<NatX>) : NatX {
         let zero = NatLib.fromNat(0);
         let one = NatLib.fromNat(1);
 
         NatLib.subWrap(zero, one);
     };
 
-    public func bits<NatX>(NatLib: NatLib<NatX>) : Nat{
+    public func bits<NatX>(NatLib : NatLib<NatX>) : Nat {
         let size = NatLib.bitcountNonZero(getMax(NatLib));
         NatLib.toNat(size);
+    };
+
+    public func getMask<NatX>(NatLib : NatLib<NatX>, i : Nat, n : Nat) : NatX {
+        var bitmask = getMax(NatLib);
+        let word_size = bits(NatLib);
+
+        if (i >= word_size) {
+            Debug.trap("NatLib getMask(): The index is out of the Nat range.");
+        };
+
+        if ((i + n) > word_size) {
+            Debug.trap("NatLib getMask(): The number of bits is out of the Nat range.");
+        };
+
+        let padding = NatLib.fromNat(word_size - (i + n));
+        bitmask := NatLib.bitshiftRight(bitmask, padding);
+        NatLib.bitshiftLeft(bitmask, NatLib.fromNat(i));
+    };
+
+    public func slice<NatX>(NatLib : NatLib<NatX>, bits : NatX, i : Nat, n : Nat) : NatX {
+        let mask = getMask(NatLib, i, n);
+        let masked = NatLib.bitand(bits, mask);
+        NatLib.bitshiftRight(masked, NatLib.fromNat(i));
+    };
+
+    public func clearSlice<NatX>(NatLib : NatLib<NatX>, bits : NatX, i : Nat, n : Nat) : NatX {
+        let mask = getMask(NatLib, i, n);
+        let flipped_mask = NatLib.bitnot(mask);
+        NatLib.bitand(bits, flipped_mask);
+    };
+
+    public func replaceSlice<NatX>(NatLib : NatLib<NatX>, bits : NatX, i : Nat, n : Nat, value : NatX) : NatX {
+        let cleared = clearSlice(NatLib, bits, i, n);
+
+        let escaped_value = NatLib.bitand(value, getMask(NatLib, 0, n));
+        let shifted_value = NatLib.bitshiftLeft(value, NatLib.fromNat(i));
+        NatLib.bitor(cleared, shifted_value);
     };
 };

--- a/tests/BitBuffer.Test.mo
+++ b/tests/BitBuffer.Test.mo
@@ -46,7 +46,7 @@ func bitbuffer_tests<NatX>(title : Text, NatLib: BitBuffer.NatLib<NatX>) : Actor
                 },
             ),
             it(
-                "set",
+                "put",
                 do {
                     let bitbuffer = BitBuffer.init(NatLib, 5, false);
 
@@ -62,42 +62,6 @@ func bitbuffer_tests<NatX>(title : Text, NatLib: BitBuffer.NatLib<NatX>) : Actor
                     ]);
                 },
             ),
-            // it(
-            //     "fromIter",
-            //     do {
-            //         let bits = [true, false, false, true, false];
-
-            //         let bitbuffer = SBB.fromIter(#Nat8, bits.vals());
-
-            //         assertAllTrue([
-            //             bitbuffer.size() == 5,
-            //             bitbuffer.get(0) == true,
-            //             bitbuffer.get(1) == false,
-            //             bitbuffer.get(2) == false,
-            //             bitbuffer.get(3) == true,
-            //             bitbuffer.get(4) == false,
-            //         ]);
-            //     },
-            // ),
-            // it(
-            //     "toIter",
-            //     do {
-            //         let bitbuffer = BitBuffer.init(NatLib, 5, true);
-
-            //         bitbuffer.put(0, true);
-            //         bitbuffer.put(3, true);
-
-            //         assertTrue(
-            //             Iter.toArray(SBB.toIter(bitbuffer)) == [
-            //                 true,
-            //                 false,
-            //                 false,
-            //                 true,
-            //                 false,
-            //             ],
-            //         );
-            //     },
-            // ),
             it(
                 "add",
                 do {
@@ -138,46 +102,23 @@ func bitbuffer_tests<NatX>(title : Text, NatLib: BitBuffer.NatLib<NatX>) : Actor
                     );
                 },
             ),
-            // it(
-            //     "removeLast",
-            //     do {
-            //         let bitbuffer = BitBuffer.BitBuffer(Nat8, 3);
+            it(
+                "removeLast",
+                do {
+                    let bitbuffer = BitBuffer.BitBuffer(Nat8, 3);
 
-            //         bitbuffer.add(true);
-            //         bitbuffer.add(false);
-            //         bitbuffer.add(true);
+                    bitbuffer.add(true);
+                    bitbuffer.add(false);
+                    bitbuffer.add(true);
 
-            //         assertAllTrue([
-            //             SBB.removeLast(bitbuffer) == ?true,
-            //             SBB.removeLast(bitbuffer) == ?false,
-            //             SBB.removeLast(bitbuffer) == ?true,
-            //             SBB.removeLast(bitbuffer) == null,
-            //         ]);
-            //     },
-            // ),
-            // it(
-            //     "setAll",
-            //     do {
-            //         let bitbuffer = BitBuffer.BitBuffer(Nat8, 8);
-
-            //         bitbuffer.add(false);
-            //         bitbuffer.add(true);
-            //         bitbuffer.add(false);
-
-            //         SBB.setAll(bitbuffer, true);
-
-            //         let firstCheckIsTrue = bitbuffer.get(0) and bitbuffer.get(1) and bitbuffer.get(2);
-
-            //         SBB.setAll(bitbuffer, false);
-
-            //         let secondCheckIsFalse = not bitbuffer.get(0) and not bitbuffer.get(1) and not bitbuffer.get(2);
-
-            //         assertAllTrue([
-            //             firstCheckIsTrue,
-            //             secondCheckIsFalse,
-            //         ]);
-            //     },
-            // ),
+                    assertAllTrue([
+                        bitbuffer.removeLast() == ?true,
+                        bitbuffer.removeLast() == ?false,
+                        bitbuffer.removeLast() == ?true,
+                        bitbuffer.removeLast() == null,
+                    ]);
+                },
+            ),
             it(
                 "invert",
                 do {
@@ -341,18 +282,80 @@ let success = run([
         "BitBuffer",
         [
             describe("BitBuffer with Nat8 word type", [
+                it("getBits", do{
+                    let bitbuffer = BitBuffer.fromWords<Nat8>(Nat8, [21, 224, 31]);
+                    let res = [
+                        bitbuffer.getBits(0, 8),
+                        bitbuffer.getBits(8, 5),
+                        bitbuffer.getBits(13, 8),
+                    ];
+                    Debug.print("res: ++ " # debug_show res);
+                    Debug.print(debug_show BitBuffer.toWords(bitbuffer));
+                    assertAllTrue([res == [21, 0, 255]])
+                }),
+                it("putBits", do {
+                    let bitbuffer = BitBuffer.fromWords<Nat8>(Nat8, [0, 0, 0]);
+
+                    bitbuffer.putBits(0, 5, 21);
+                    bitbuffer.putBits(5, 8, 255);
+                    bitbuffer.putBits(13, 7, 64);
+
+                    assertAllTrue([
+                        bitbuffer.getBits(0, 5) == 21,
+                        bitbuffer.getBits(5, 8) == 255,
+                        bitbuffer.getBits(13, 7) == 64,
+                    ])
+                }),
                 it("addBits", do {
                     let bitbuffer = BitBuffer.BitBuffer<Nat8>(Nat8, 8);
                     bitbuffer.addBits(8, 21);
                     bitbuffer.addBits(5, 0);
                     bitbuffer.addBits(8, 255);
 
-                    Debug.print(debug_show bitbuffer.size());
-                    Debug.print(debug_show Iter.toArray(bitbuffer.words()));
                     assertAllTrue([
                         bitbuffer.size() == 21,
-                        Iter.toArray(bitbuffer.words()) == [21, 7, 31],
+                        Iter.toArray(bitbuffer.words()) == [21, 224, 31],
                     ]);
+                }),
+
+                it("fromWords", do{
+                    let bitbuffer = BitBuffer.fromWords<Nat8>(Nat8, [21, 224, 31]);
+                    assertAllTrue([
+                        bitbuffer.size() == 24,
+                        BitBuffer.toWords(bitbuffer) == [21, 224, 31],
+                    ])
+                }),
+                it("insertBits", do{
+                    let bitbuffer = BitBuffer.BitBuffer<Nat8>(Nat8, 21);
+
+                    Debug.print("insertBits");
+                    let res = [
+                        do {
+                            bitbuffer.addBits(2, 3);
+                            Debug.print("test: getBits(0, 2): " # debug_show bitbuffer.getBits(0, 2));
+                            bitbuffer.getBits(0, 2) == 3 
+                        },
+                        bitbuffer.size() == 2,
+                        do {
+                            bitbuffer.insertBits(1, 3, 2);
+                            Debug.print("test: getBits(1, 3): " # debug_show bitbuffer.getBits(1, 3));
+                            bitbuffer.getBits(1, 3) == 2
+                        },
+                        bitbuffer.size() == 5,
+
+                        do{
+                            bitbuffer.insertBits(0, 3, 0);
+                            Debug.print("test: getBits(0, 3): " # debug_show bitbuffer.getBits(0, 3));
+                            bitbuffer.getBits(0, 3) == 0
+                        },
+                        bitbuffer.size() == 8,
+
+                    ];
+
+                    Debug.print("res" # debug_show res);
+
+                    assertAllTrue(res)
+
                 })
             ]),
             // bitbuffer_tests<Nat8>("With Nat8 Word", Nat8),


### PR DESCRIPTION
- add BitBuffer<NatX> class
- remove StableBitBuffer32 module
- remove StableBitBuffer module with variant type
- Add NatLib module with type for specifying NatX libs